### PR TITLE
fixes installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A macOS utility that helps reduce distraction by dimming your inactive noise
 #### Using Homebrew
 
 ```
-brew cask install blurred
+brew install --cask blurred
 ```
 
 #### Manual download


### PR DESCRIPTION
fixes installation command due to the below error 
```shell
Error: `brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead.
```